### PR TITLE
change ufw port for glance to 9393 from 9293.

### DIFF
--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -30,7 +30,7 @@
   ufw: rule=allow to_port={{ item }} proto=tcp
   with_items:
     - 9292
-    - 9293
+    - 9393
 
 - name: install glance services
   upstart_service: name={{ item }}


### PR DESCRIPTION
Wrong glance haproxy https ufw port 9293 was being opened. Fix is to open up 9393 port.
